### PR TITLE
fix: support make gemm in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 CC_FILES=$(shell find ./ -name "*.cu")
 EXE_FILES=$(CC_FILES:.cu=)
 
+.PHONY: all clean gemm
+
 all:$(EXE_FILES)
+
+gemm: gemm-multi-stage gemm-simple
 
 %:%.cu
 	nvcc -o $@ $< -O2 -arch=sm_86 -std=c++17 -I3rd/cutlass/include --expt-relaxed-constexpr -cudart shared --cudadevrt none -lcublasLt -lcublas


### PR DESCRIPTION
Makefile: add GEMM targets (gemm-multi-stage, gemm-simple) to prevent non-Hopper build failures